### PR TITLE
Implement PortSwHOQLifetiemLimitDiscards metric

### DIFF
--- a/infiniband-exporter-el7.spec
+++ b/infiniband-exporter-el7.spec
@@ -1,5 +1,5 @@
 Name:	  infiniband-exporter
-Version:  0.0.4
+Version:  0.0.5
 %global gittag 0.0.4
 Release:  1%{?dist}
 Summary:  Prometheus exporter for a Infiniband Fabric

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -13,7 +13,7 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client import make_wsgi_app
 from wsgiref.simple_server import make_server, WSGIRequestHandler
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 class ParsingError(Exception):
     pass

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -61,8 +61,6 @@ class InfinibandCollector(object):
                 'severity': 'Error',
                 'bits': 16,
             },
-            # detailed description of xmitDiscards: (Head of Queue) timeout https://community.mellanox.com/s/article/howto-prevent-infiniband-credit-loops
-            # possibly interesting to also monitor a lot of similar performance metrics that have been introduced in the kernel at the same time https://patchwork.kernel.org/project/linux-rdma/patch/0F3DDD57-C1A9-4304-A20F-7027BF8F590B@llnl.gov/
             'PortSwHOQLifetimeLimitDiscards': {
                 'help': 'The number of packets dropped by running in a head-of-Queue timeout'
                         'often caused by congestions, possibly by credit Loops.',

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -61,6 +61,7 @@ class InfinibandCollector(object):
                 'severity': 'Error',
                 'bits': 16,
             },
+            # detailed description of xmitDiscards: (Head of Queue) timeout https://community.mellanox.com/s/article/howto-prevent-infiniband-credit-loops
             'PortSwHOQLifetimeLimitDiscards': {
                 'help': 'The number of packets dropped by running in a head-of-Queue timeout'
                         'often caused by congestions, possibly by credit Loops.',

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -61,6 +61,14 @@ class InfinibandCollector(object):
                 'severity': 'Error',
                 'bits': 16,
             },
+            # detailed description of xmitDiscards: (Head of Queue) timeout https://community.mellanox.com/s/article/howto-prevent-infiniband-credit-loops
+            # possibly interesting to also monitor a lot of similar performance metrics that have been introduced in the kernel at the same time https://patchwork.kernel.org/project/linux-rdma/patch/0F3DDD57-C1A9-4304-A20F-7027BF8F590B@llnl.gov/
+            'PortSwHOQLifetimeLimitDiscards': {
+                'help': 'The number of packets dropped by running in a head-of-Queue timeout'
+                        'often caused by congestions, possibly by credit Loops.',
+                'severity': 'Informative',
+                'bits': 16,
+            },
             'PortXmitWait': {
                 'help': 'The number of ticks during which the port had data '
                         'to transmit but no data was sent during the entire '


### PR DESCRIPTION
Implements a new metric.

Changes on examplic input file

infiniband-exporter.py log before/after change (except PortXmitWait Warnings):
``` diff
< 2021-11-10 18:30:43,489 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards
2021-11-10 18:30:43,512 - WARNING - Counters on 0xc42a10300dd0c0e port 1 is maxed out on PortRcvErrors
< 2021-11-10 18:30:43,527 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards
< 2021-11-10 18:30:43,537 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards
2021-11-10 18:30:43,538 - WARNING - Counters on 0xc42a10300dce3da port 1 is maxed out on PortRcvErrors
2021-11-10 18:30:43,547 - WARNING - Counters on 0x98039b030067ab58 port 1 is maxed out on PortXmitDiscards
2021-11-10 18:30:43,555 - WARNING - Counters on 0xc42a10300e91b7c port 1 is maxed out on PortRcvErrors
2021-11-10 18:30:43,559 - WARNING - Counters on 0x506b4b03007d8621 port 1 is maxed out on PortXmitDiscards
2021-11-10 18:30:43,559 - WARNING - Counters on 0x506b4b03007d8671 port 1 is maxed out on PortXmitDiscards
2021-11-10 18:30:43,572 - WARNING - Counters on 0xc42a10300dce83a port 1 is maxed out on PortRcvErrors
< 2021-11-10 18:30:43,582 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards
< 2021-11-10 18:30:43,587 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards

```
curl output diff before/after change:
```diff
529a530,536
> # HELP infiniband_portswhoqlifetimelimitdiscards_total The number of packets dropped by running in a head-of-Queue timeoutoften caused by congestions, possibly by credit Loops.
> # TYPE infiniband_portswhoqlifetimelimitdiscards_total counter
> infiniband_portswhoqlifetimelimitdiscards_total{component="ca",local_guid="XXXX",local_name="XXXX XXXX",local_port="1",remote_guid="0xf4521403009536e0",remote_name="XXX;leaf-XXXX",remote_port="23"} 44.0
> infiniband_portswhoqlifetimelimitdiscards_total{component="ca",local_guid="XXXX",local_name="XXXX XXXX",local_port="1",remote_guid="0xe41d2d030007e6a0",remote_name="SwitchX -  Mellanox Technologies",remote_port="10"} 12.0
> infiniband_portswhoqlifetimelimitdiscards_total{component="ca",local_guid="XXXX",local_name="XXXX XXXX",local_port="1",remote_guid="0xf45214030095bff0",remote_name="XXX;leaf-XXXX",remote_port="24"} 6.0
> infiniband_portswhoqlifetimelimitdiscards_total{component="ca",local_guid="XXXX",local_name="XXXX XXXX",local_port="1",remote_guid="0xXXX",remote_name="XXX;leaf-XXXX",remote_port="32"} 13.0
> infiniband_portswhoqlifetimelimitdiscards_total{component="ca",local_guid="XXXX",local_name="XXXX XXXX",local_port="1",remote_guid="0xf45214030095de90",remote_name="XXX;leaf-XXXX",remote_port="33"} 15.0
40125c40132
< infiniband_scrape_duration_seconds 0.7428021430969238
---
> infiniband_scrape_duration_seconds 0.755831241607666
40128c40135
< infiniband_scrape_ok 0.0
---
> infiniband_scrape_ok 1.0

```